### PR TITLE
Add ability to get custom data per page

### DIFF
--- a/src/pipeline/limit/customData.ts
+++ b/src/pipeline/limit/customData.ts
@@ -1,0 +1,39 @@
+import Tabular from '../../tabular';
+import {
+  PipelineProcessor,
+  PipelineProcessorProps,
+  ProcessorType,
+} from '../processor';
+
+interface CustomDataProps extends PipelineProcessorProps {
+  page: number;
+  limit: number;
+  data: (page: number, limit: number) => Promise<any[]>;
+}
+
+class CustomDataLimit extends PipelineProcessor<Tabular, CustomDataProps> {
+  protected validateProps(): void {
+    if (
+      isNaN(Number(this.props.limit)) ||
+      isNaN(Number(this.props.page)) ||
+      !this.props.data
+    ) {
+      throw Error('Invalid parameters passed');
+    }
+  }
+
+  get type(): ProcessorType {
+    return ProcessorType.Limit;
+  }
+
+  protected async _process(): Promise<Tabular> {
+    const data = await this.props.data(this.props.page, this.props.limit);
+
+    const tab = Tabular.fromArray(data);
+    tab.length = data.length;
+
+    return tab;
+  }
+}
+
+export default CustomDataLimit;


### PR DESCRIPTION
TODO: Unit tests

These changes add the ability to get "custom data" per page.

This is useful for cases where you may need to send and get specific data from an API. Currently GridJS does not completely support this, the best we get is limit/offset pagination.

For example, this feature allows you to do this
```javascript
const getData = async (page, limit) => {
  // This could be a call to your API where you can send specific data based on the page/limit
  const data = [
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9],
    [10, 11, 12],
  ];

  const start = page * limit;
  const end = (page + 1) * limit;

  return data.slice(start, end);
};

useEffect(() => {
  grid = new Grid({
    columns: ['a', 'b', 'c'],
    pagination: {
      limit: 2,
      forceTotal: 20,
      customData: (page, limit) => getData(page, limit),
    },
    data: [],
  }).render(ref.current);
});
```

When you paginate `getData` gets called with the relevant arguments.

To use this, you need to set `forceTotal` and `customData` in the `pagination` option. It's best to keep `data` as an empty array, such as above.

`customData` will need to return a `Promise`.
`forceTotal` should be the total number of results that is expected.